### PR TITLE
Fix SSL polling

### DIFF
--- a/src/mesos_state_client.erl
+++ b/src/mesos_state_client.erl
@@ -63,7 +63,12 @@ poll() ->
   Proto = proto(),
   poll(Proto ++ "://localhost:5051/state").
 
--spec(poll(URI :: string()) -> {ok, mesos_agent_state()} | {error, Reason :: term()}).
+-spec(poll(string() | inet:ip_address()) -> {ok, mesos_agent_state()} | {error, Reason :: term()}).
+poll(IP) when is_tuple(IP) ->
+  Proto = proto(),
+  IPStr = inet:ntoa(IP),
+  URI = lists:flatten(Proto ++ "://" ++ IPStr ++ "/state"),
+  poll(URI);
 poll(URI) ->
   Options = [
     {timeout, application:get_env(?APP, timeout, ?DEFAULT_TIMEOUT)},


### PR DESCRIPTION
This patch makes it so that the poll API can take the IP + Port,
and then it can derive the URI, and whether to use HTTPS based on
internal state.