### PR TITLE
Docker network type 'BRIDGE' does not always parse.

### DIFF
--- a/src/mesos_state_client.erl
+++ b/src/mesos_state_client.erl
@@ -317,11 +317,19 @@ port_mapping(#{container_port := ContainerPort, host_port := HostPort, protocol 
 force_pull_image(#{force_pull_image := ForcePullImage}) -> ForcePullImage;
 force_pull_image(_) -> false.
 
+network_type(BinString) when is_binary(BinString) ->
+    String = binary_to_list(BinString),
+    case string:to_lower(String) of
+        "bridge" -> 'bridge';
+        "host" -> 'host';
+        "user" -> 'user'
+    end.
+
 docker(#{image := Image, network := Network} = Docker) ->
     #docker{
        force_pull_image = force_pull_image(Docker),
        image = Image,
-       network = list_to_existing_atom(string:to_lower(binary_to_list(Network))),
+       network = network_type(Network),
        port_mappings = port_mappings(Docker)}.
 
 task_statuses([], Acc) ->

--- a/test/mesos_state_SUITE_data/state6.json
+++ b/test/mesos_state_SUITE_data/state6.json
@@ -4774,7 +4774,7 @@
                         "docker": {
                             "force_pull_image": true,
                             "image": "calico/calico-dcos:v0.1.0",
-                            "network": "HOST",
+                            "network": "BRIDGE",
                             "privileged": false
                         },
                         "type": "DOCKER"


### PR DESCRIPTION
Addresses DCOS-13273. The `list_to_existing_atom` was relying on the existence of the `bridge` atom present in `mesos_state.hrl`, but we now no that this is not a reliable way to guarantee the existence of an atom.